### PR TITLE
NA - Expose FlushError() client method

### DIFF
--- a/client.go
+++ b/client.go
@@ -117,3 +117,8 @@ func (c *Client) PutAggregated(name string, value float64, tags Tags, timestamp 
 func (c *Client) Flush() {
 	c.buffer.Flush()
 }
+
+// FlushError flushes the client buffer and returns a FlushErr error if any errors happen.
+func (c *Client) FlushError() error {
+	return c.buffer.FlushError()
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,32 @@
+package statful
+
+import (
+	"fmt"
+	"strings"
+)
+
+type FlushErr struct {
+	errors []error
+}
+
+const (
+	flushErrors    = "flush errors"
+	flushErrorsSep = "; "
+)
+
+func (f FlushErr) Error() string {
+	var errStrs []string
+	for _, err := range f.errors {
+		errStrs = append(errStrs, err.Error())
+	}
+	return fmt.Sprintf("%s: %s", flushErrors, strings.Join(errStrs, flushErrorsSep))
+}
+
+func (f FlushErr) appendErr(err error) FlushErr {
+	f.errors = append(f.errors, err)
+	return f
+}
+
+func (f FlushErr) hasErrors() bool {
+	return len(f.errors) > 0
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,27 @@
+package statful
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestFlushErr_Error(t *testing.T) {
+	var flushErr FlushErr
+
+	flushErr = flushErr.appendErr(errors.New("err 1"))
+	flushErr = flushErr.appendErr(errors.New("err 2"))
+
+	if !flushErr.hasErrors() {
+		t.Error("hasError() returned: false, expected: true")
+	}
+
+	expectedErrStr := fmt.Sprintf(
+		"%s: %s",
+		flushErrors,
+		fmt.Sprintf("%s%s%s", "err 1", flushErrorsSep, "err 2"))
+	flushErrStr := flushErr.Error()
+	if flushErrStr != expectedErrStr {
+		t.Errorf("Error() returned: %s, expected: %s", flushErrStr, expectedErrStr)
+	}
+}


### PR DESCRIPTION
This method can be used by applications that require control on whether the client buffer is successfully flushed.

This change adds a new method, instead of modifying Flush(), to avoid breaking compatibility.